### PR TITLE
Increased message length from 200 to 250

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -7,9 +7,17 @@ namespace RazorPagesTestSample.Data
     {
         public int Id { get; set; }
 
-        [Required]
+        /// <summary>
+        /// Gets or sets the text of the message.
+        /// </summary>
+        /// <remarks>
+        /// This property is required and must not exceed 200 characters.
+        /// If the message exceeds this limit, an error message will be provided:
+        /// "There's a 250 character limit on messages. Please shorten your message."
+        /// </remarks>
+        /// /// /// /// /// /// /// /// [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
This pull request includes a change to the `Message` class in the `RazorPagesTestSample` project to improve the documentation and validation of the `Text` property.

Documentation and validation improvements:

* [`src/Application/src/RazorPagesTestSample/Data/Message.cs`](diffhunk://#diff-3ce635672d23bd9cdaa8656d8d117fc07bbea38b87de905339a765df73f3c450L10-R20): Added XML documentation comments to the `Text` property, updated the character limit from 200 to 250, and revised the error message accordingly.